### PR TITLE
Support custom paper sizes

### DIFF
--- a/DYI_Main.tex
+++ b/DYI_Main.tex
@@ -29,12 +29,6 @@
 
 \usepackage{afterpage}
 
-\newcommand\blankpage{%
-    \null
-    \thispagestyle{empty}%
-    \addtocounter{page}{-1}%
-    \newpage}
-
 %--------------------------------------------------------------------
 % Document-wide settings
 

--- a/DYI_Main.tex
+++ b/DYI_Main.tex
@@ -32,13 +32,9 @@
 %--------------------------------------------------------------------
 % Document-wide settings
 
-%% paper: A5 is 148mm x 210mm
-% 18mm on binding -> text area = 120mm x 190mm
-\geometry{a5paper}
+\input{DYI_config}
 \geometry{portrait}
 \geometry{inner=18mm,outer=10mm,top=10mm,bottom=10mm}
-% Below is for lulu hardcover
-%\geometry{paperheight=22.86cm,paperwidth=15.24cm}
 
 % Don't show page numbers
 \pagestyle{empty}

--- a/DYI_Main.tex
+++ b/DYI_Main.tex
@@ -1,4 +1,4 @@
-\documentclass[a5paper,twoside]{article}
+\documentclass[twoside]{article}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Packages
@@ -6,7 +6,7 @@
 \usepackage[utf8]{inputenc}
 
 % paper settings
-\usepackage{vmargin}
+\usepackage{geometry}
 
 % macro helpers
 \usepackage{xspace}
@@ -39,12 +39,15 @@
 % Document-wide settings
 
 %% paper: A5 is 148mm x 210mm
-\setpapersize[portrait]{A5}
-% Below is for lulu hardcover
-%\setpapersize{custom}{15.24cm}{22.86cm}
-
 % 18mm on binding -> text area = 120mm x 190mm
-\setmargnohfrb{18mm}{10mm}{10mm}{10mm}
+\geometry{a5paper}
+\geometry{portrait}
+\geometry{inner=18mm,outer=10mm,top=10mm,bottom=10mm}
+% Below is for lulu hardcover
+%\geometry{paperheight=22.86cm,paperwidth=15.24cm}
+
+% Don't show page numbers
+\pagestyle{empty}
 
 % Default font: Avantgarde
 %\usepackage{avant}

--- a/coloring.tex
+++ b/coloring.tex
@@ -1,14 +1,13 @@
-\vspace*{-1.5cm}\noindent\makebox[14.85cm][c]{\includegraphics[width=148mm,height=210mm]{./artwork/space}}
-\blankpage
-\vspace*{-1.5cm}
-\noindent
-\makebox[14.85cm][c]{\includegraphics[width=148mm,height=210mm]{./artwork/data_center}}
-\blankpage
-\vspace*{-1.5cm}
-\noindent
-\makebox[14.85cm][c]{\includegraphics[width=148mm,height=210mm]{./artwork/zengarden}}
-\blankpage
-\vspace*{-1.5cm}
-\noindent
-\makebox[14.85cm][c]{\includegraphics[width=148mm,height=210mm]{./artwork/london}}
-\blankpage
+% We don't want any outside margins for the color pages
+\newgeometry{inner=18mm,outer=0mm,top=0mm,bottom=0mm}
+
+\includegraphics[width=\textwidth,height=\textheight]{./artwork/space}
+\cleardoublepage
+\includegraphics[width=\textwidth,height=\textheight]{./artwork/data_center}
+\cleardoublepage
+\includegraphics[width=\textwidth,height=\textheight]{./artwork/zengarden}
+\cleardoublepage
+\includegraphics[width=\textwidth,height=\textheight]{./artwork/london}
+\cleardoublepage
+
+\restoregeometry

--- a/gen_Current_Macros.py
+++ b/gen_Current_Macros.py
@@ -122,6 +122,15 @@ def write_out_i18n_macros(file):
         i18n_macros_FH.writelines('\\newcolumntype{G}{>{\\hfill\\bfseries\\tiny}p{\\WkdayColWidthMinicalMP}@{\\extracolsep\\fill}}\n')
 
 #--------------------------------------------------------------------
+# Generate & write out a config tex file for latex-specific configuration
+#
+# This just includes paper size at the moment
+
+def write_out_latex_config(file):
+    config_FH = open(file, 'w')
+    config_FH.writelines('\\geometry{' + cfg.paper_size + '}\n')
+
+#--------------------------------------------------------------------
 # generate one \MonthTbl<month_abbr> macro for the given month
 #
 # also \MonthTbl<month_abbr>Prev and \MonthTbl<month_abbr>Next
@@ -502,6 +511,7 @@ def write_out_WP_macros(year, file):
 # Main
 
 write_out_i18n_macros('DYI_i18n.tex')
+write_out_latex_config('DYI_config.tex')
 write_out_MonthTbl_macros(cfg.year, 'DYI_Month_Tables.tex')
 write_out_MP_macros(cfg.year, 'DYI_Monthly_Planner_Tables.tex')
 write_out_WP_macros(cfg.year, 'DYI_Weekly_Planner_Tables.tex')

--- a/gen_config.py
+++ b/gen_config.py
@@ -9,6 +9,11 @@ year = 2019
 # True if the week starts on Monday (European convention), False if it starts on Sunday.
 week_starts_on_Monday = True
 
+# What paper size should be output?
+paper_size = 'a5paper'
+# Use paper_size = 'paperheight=8.5in,paperwidth=5.5in' for half letter,
+# paper_size = 'paperheight=9in,paperwidth=6in' for lulu hardcover.
+
 # Locale -- uncomment one only, use utf-8 encoding ONLY
 #
 #locale.setlocale(locale.LC_ALL, 'en_AU.utf-8')      # Australia

--- a/paper.tex
+++ b/paper.tex
@@ -1,35 +1,52 @@
-%text area = 120mm x 190mm
+
+\pgfmathsetmacro{\gridWidthCm}{\textwidth/1cm}
+\newdimen\tikzspacer
+\tikzspacer=18pt
+
 \rpt[10]{
 \section{dots}
-  \begin{tikzpicture}[scale=.5]
-    \foreach \x in {0,...,24}
-    \foreach \y in {0,...,35}
+\newdimen\spaceleft
+\spaceleft=\dimexpr\textheight-\pagetotal-\tikzspacer\relax
+\pgfmathsetmacro{\gridHeightCm}{\spaceleft/1cm}
+% Needed to subtract an extra 14pt to prevent the page content from jumping
+% to the next page in some cases.
+  \begin{tikzpicture}
+    \foreach \x in {0,0.5,...,\gridWidthCm}
+    \foreach \y in {0,0.5,...,\gridHeightCm}
     {
-  \fill (\x cm,\y cm) circle (0.03cm);
+  \fill (\x cm,\y cm) circle (0.015cm);
     }       
   \end{tikzpicture}
   \pagebreak
-  }
+}
 \rpt[10]{
   \section{triangular}
-  \begin{tikzpicture}[scale=.5]
-    \foreach \x [count=\xi] in {0,...,24}
-    \foreach \y [count=\yi] in {0,2,...,35}
+  \newdimen\spaceleft
+  \spaceleft=\dimexpr\textheight-\pagetotal-\tikzspacer\relax
+  \pgfmathsetmacro{\gridHeightCm}{\spaceleft/1cm}
+  \begin{tikzpicture}
+    \foreach \x [count=\xi] in {0,0.5,...,\gridWidthCm}
+    \foreach \y [count=\yi] in {0,1,...,\gridHeightCm}
     {
-  \fill (\x cm,\y cm) circle (0.03cm);
+  \fill (\x cm,\y cm) circle (0.015cm);
     }       
-    \foreach \x [count=\xi] in {0.5,...,24}
-    \foreach \y [count=\yi] in {1,3,...,35}
+    \foreach \x [count=\xi] in {0.25,0.75,...,\gridWidthCm}
+    \foreach \y [count=\yi] in {0.5,1.5,...,\gridHeightCm}
     {
-  \fill (\x cm,\y cm) circle (0.03cm);
+  \fill (\x cm,\y cm) circle (0.015cm);
     }       
   \end{tikzpicture}
   \pagebreak
 }
 \rpt[6]{
  \section{graph}
-  \begin{tikzpicture}[scale=.5]
-\draw [very thin, gray] (0,0) grid (25,35);
+  \newdimen\spaceleft
+  \spaceleft=\dimexpr\textheight-\pagetotal-\tikzspacer\relax
+  \pgfmathsetlengthmacro{\graphWidth}{\textwidth - mod(\textwidth,0.5cm)}
+  \pgfmathsetlengthmacro{\graphHeight}{\spaceleft - mod(\spaceleft,0.5cm)}
+  % Have to use mod here to get an even number of grid cells
+  \begin{tikzpicture}
+\draw [very thin, gray, step=0.5cm] (0,0) grid (\graphWidth,\graphHeight);
   \end{tikzpicture}
 \pagebreak
 }


### PR DESCRIPTION
I can't source A5 paper locally, so will need to instead use half-letter paper.  Almost everything converts to half-letter fine except for some of the graph and coloring pages, which needed a few small tweaks.